### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/yohantobon/b1a6b405-cd00-42bc-8b5a-a6cdc0e3f0f5/1a400bba-40f1-4e2c-a87c-595142748733/_apis/work/boardbadge/263b0569-c981-4542-9698-db1949bdf9c1)](https://dev.azure.com/yohantobon/b1a6b405-cd00-42bc-8b5a-a6cdc0e3f0f5/_boards/board/t/1a400bba-40f1-4e2c-a87c-595142748733/Microsoft.RequirementCategory)
 Libs:
 cargo-edit
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/yohantobon/b1a6b405-cd00-42bc-8b5a-a6cdc0e3f0f5/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.